### PR TITLE
Fix NullPointerException

### DIFF
--- a/src/main/kotlin/me/realrobotix/customcrosshair/render/ShapeRenderer.kt
+++ b/src/main/kotlin/me/realrobotix/customcrosshair/render/ShapeRenderer.kt
@@ -54,7 +54,7 @@ abstract class ShapeRenderer {
 
     fun getEntityLookingAtType(): Int {
         if (mc.theWorld == null) return -1
-        val entity = mc.objectMouseOver.entityHit ?: return -1
+        val entity = mc.objectMouseOver?.entityHit ?: return -1
         return when (entity) {
             is EntityPlayer -> 0
             is EntityAgeable -> 1


### PR DESCRIPTION
This error rarely happens, and I don't know how this happened.
However, because Minecraft itself checks if objectMouseOver is not null in every place, it's reasonable that we should also check if objectMouseOver is not null.

```
---- Minecraft Crash Report ----

WARNING: coremods are present:
  ModTweaker (PolyPatcher-1.8.9-forge-1.10.2.jar)
  PatcherTweaker (PolyPatcher-1.8.9-forge-1.10.2.jar)
Contact their authors BEFORE contacting forge

// Quite honestly, I wouldn't worry myself about that.

Time: 4/23/25 3:04 PM
Description: Unexpected error

java.lang.NullPointerException: Unexpected error
	at me.realrobotix.customcrosshair.render.ShapeRenderer.getEntityLookingAtType(ShapeRenderer.kt:57)
	at me.realrobotix.customcrosshair.render.ShapeRenderer.getReactiveColor(ShapeRenderer.kt:78)
	at me.realrobotix.customcrosshair.render.CrossRenderer.draw(CrossRenderer.kt:7)
	at me.realrobotix.customcrosshair.CustomCrosshair.drawCrosshair$lambda$0(CustomCrosshair.kt:41)
	at cc.polyfrost.oneconfig.internal.renderer.NanoVGHelperImpl.setupAndDraw(NanoVGHelperImpl.java:146)
	at cc.polyfrost.oneconfig.internal.renderer.NanoVGHelperImpl.setupAndDraw(NanoVGHelperImpl.java:111)
	at me.realrobotix.customcrosshair.CustomCrosshair.drawCrosshair(CustomCrosshair.kt:40)
	at me.realrobotix.customcrosshair.CustomCrosshair.onRender(CustomCrosshair.kt:56)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_6_CustomCrosshair_onRender_Post.invoke(.dynamic)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:49)
	at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at net.minecraftforge.client.GuiIngameForge.post(GuiIngameForge.java:851)
	at net.minecraftforge.client.GuiIngameForge.renderCrosshairs(GuiIngameForge.java:201)
	at net.minecraftforge.client.GuiIngameForge.func_175180_a(GuiIngameForge.java:126)
	at club.sk1er.patcher.screen.render.caching.HUDCaching.renderCachedHud(HUDCaching.java:130)
	at net.minecraft.client.renderer.EntityRenderer.redirect$patcher$renderCachedHUD$zpk000(EntityRenderer.java:11059)
	at net.minecraft.client.renderer.EntityRenderer.func_181560_a(EntityRenderer.java:1396)
	at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1051)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:349)
	at net.minecraft.client.main.Main.main(SourceFile:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
```